### PR TITLE
Add keys.openpgp.org as the keyserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN usermod -d /home www-data \
     # gosu
     && export GOSU_VERSION='1.10' \
     && mkdir ~/.gnupg && chmod 600 ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
-    && for server in hkp://ipv4.pool.sks-keyservers.net:80 \
+    && for server in hkps://keys.openpgp.org \
+                     hkp://ipv4.pool.sks-keyservers.net:80 \
                      hkp://ha.pool.sks-keyservers.net:80 \
                      hkp://pgp.mit.edu:80 \
                      hkp://keyserver.pgp.com:80 \


### PR DESCRIPTION
## Purpose

gosu ビルド時のkeyserverにkeys.openpgp.orgを追加する。

ceb957390770eaea012858ae282978295d7759a4

下記のようにビルドに失敗する。

https://github.com/tianon/gosu?tab=readme-ov-file#installation にも

> 3. fetch my public key (to verify your download): `gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4`

とある。


```
89.27 Unpacking libshine3:amd64 (3.1.1-2) ...
  30 | >>>         # convert .step to jsc3d-compatible format
  31 | >>>         freecad \
  32 | >>>         # pspp dependencies
  33 | >>>         pspp \
  34 | >>>         # unoconv dependencies
  35 | >>>         libreoffice \
  36 | >>>         # gosu dependencies
  37 | >>>         curl \
  38 | >>>         gnupg2 \
  39 | >>>     # gosu
  40 | >>>     && export GOSU_VERSION='1.10' \
  41 | >>>     && mkdir ~/.gnupg && chmod 600 ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  42 | >>>     && for server in hkp://ipv4.pool.sks-keyservers.net:80 \
  43 | >>>                      hkp://ha.pool.sks-keyservers.net:80 \
  44 | >>>                      hkp://pgp.mit.edu:80 \
  45 | >>>                      hkp://keyserver.pgp.com:80 \
  46 | >>>     ; do \
  47 | >>>       gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || echo "Trying new server..." \
  48 | >>>     ; done \
  49 | >>>     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
  50 | >>>      && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
  51 | >>>      && gpg --verify /usr/local/bin/gosu.asc \
  52 | >>>      && rm /usr/local/bin/gosu.asc \
  53 | >>>      && chmod +x /usr/local/bin/gosu \
  54 | >>>     # /gosu
  55 | >>>     && apt-get clean \
  56 | >>>     && apt-get autoremove -y \
  57 | >>>         curl \
  58 | >>>         gnupg2 \
  59 | >>>     && rm -rf /var/lib/apt/lists/* \
  60 | >>>     && pip install -U pip \
  61 | >>>     && pip install setuptools==37.0.0 \
  62 | >>>     && mkdir -p /code \
  63 | >>>     && pip install unoconv==0.8.2
  64 |
--------------------
ERROR: failed to solve: process "/bin/sh -c usermod -d /home www-data     && chown www-data:www-data /home     && mkdir -p /usr/share/man/man1     && apt-get update     && apt-get install -y ca-certificates-java     && apt-get install -y         git         make         gcc         build-essential         gfortran         r-base         libblas-dev         libevent-dev         libfreetype6-dev         libjpeg-dev         libpng-dev         libtiff5-dev         libxml2-dev         libxslt1-dev         zlib1g-dev         freecad         pspp         libreoffice         curl         gnupg2     && export GOSU_VERSION='1.10'     && mkdir ~/.gnupg && chmod 600 ~/.gnupg && echo \"disable-ipv6\" >> ~/.gnupg/dirmngr.conf     && for server in hkp://ipv4.pool.sks-keyservers.net:80                      hkp://ha.pool.sks-keyservers.net:80                      hkp://pgp.mit.edu:80                      hkp://keyserver.pgp.com:80     ; do       gpg --keyserver \"$server\" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || echo \"Trying new server...\"     ; done     && curl -o /usr/local/bin/gosu -SL \"https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)\"   \t&& curl -o /usr/local/bin/gosu.asc -SL \"https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc\"   \t&& gpg --verify /usr/local/bin/gosu.asc   \t&& rm /usr/local/bin/gosu.asc   \t&& chmod +x /usr/local/bin/gosu     && apt-get clean     && apt-get autoremove -y         curl         gnupg2     && rm -rf /var/lib/apt/lists/*     && pip install -U pip     && pip install setuptools==37.0.0     && mkdir -p /code     && pip install unoconv==0.8.2" did not complete successfully: exit code: 2
```

最小のテストコード

```bash
#!/bin/sh
for server in hkp://ipv4.pool.sks-keyservers.net:80 \
              hkp://ha.pool.sks-keyservers.net:80 \
              hkp://pgp.mit.edu:80 \
              hkp://keyserver.pgp.com:80
do
	echo "*** $server ***"

	gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || echo "Trying new server..."
done
```

実行結果

```
*** hkp://ipv4.pool.sks-keyservers.net:80 ***
gpg: keyserver receive failed: No keyserver available
Trying new server...
*** hkp://ha.pool.sks-keyservers.net:80 ***
gpg: keyserver receive failed: No keyserver available
Trying new server...
*** hkp://pgp.mit.edu:80 ***
gpg: keyserver receive failed: No keyserver available
Trying new server...
*** hkp://keyserver.pgp.com:80 ***
gpg: keyserver receive failed: No keyserver available
Trying new server...
```



## Changes



<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
