### PR TITLE
extract metadata from redirect headers to avoid redundant WB req

### DIFF
--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -34,6 +34,7 @@ class OsfProvider(provider.BaseProvider):
         super().__init__(request, url, action)
         self.download_url = None
         self.headers = {}
+        self._cached_metadata = None
 
         # capture request authorization
         self.cookies = dict(self.request.cookies)
@@ -60,7 +61,10 @@ class OsfProvider(provider.BaseProvider):
         """
         download_url = await self._fetch_download_url()
         logger.debug('download_url::{}'.format(download_url))
-        if '/file?' in download_url:
+        if self._cached_metadata:
+            metadata = self._cached_metadata
+            self.metrics.add('metadata.wb_api', 'cached_from_head')
+        elif '/file?' in download_url:
             # URL is for WaterButler v0 API
             # TODO Remove this when API v0 is officially deprecated
             self.metrics.add('metadata.wb_api', 'v0')
@@ -171,7 +175,7 @@ class OsfProvider(provider.BaseProvider):
                 self.metrics.add('download_url.orig_type', 'osf')
                 # make request to osf, don't follow, store waterbutler download url
                 request = await self._make_request(
-                    'GET',
+                    'HEAD',
                     self.url,
                     allow_redirects=False,
                     headers={
@@ -189,6 +193,7 @@ class OsfProvider(provider.BaseProvider):
                         code=request.status,
                     )
                 self.download_url = request.headers['location']
+                self._cached_metadata = {'data': json.loads(request.headers['x-file-metadata'])}
 
             self.metrics.add('download_url.derived_url', str(self.download_url))
 
@@ -206,3 +211,4 @@ class OsfProvider(provider.BaseProvider):
             kwargs.setdefault('headers', {})['Authorization'] = 'Bearer ' + self.token
 
         return await aiohttp.request(method, url, *args, **kwargs)
+        

--- a/mfr/providers/osf/provider.py
+++ b/mfr/providers/osf/provider.py
@@ -211,4 +211,3 @@ class OsfProvider(provider.BaseProvider):
             kwargs.setdefault('headers', {})['Authorization'] = 'Bearer ' + self.token
 
         return await aiohttp.request(method, url, *args, **kwargs)
-        


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/55671
https://redmine.devops.rcos.nii.ac.jp/issues/55665
## Purpose

ファイルレンダラーのパフォーマンス最適化を目的としたプルリクエストです。OSFからのメタデータ取得を効率化し、不要なリクエストを削減します。

## Changes

メタデータキャッシング機構の導入

_cached_metadata フィールドを追加してメタデータをキャッシュ
metadata メソッドでキャッシュの有無を最初にチェック
キャッシュが存在する場合は、WaterButler APIへのリクエストをスキップ
メトリクスに 'cached_from_head' を記録


HTTPメソッドの変更

_fetch_download_url メソッドのリクエストを GET → HEAD に変更
HEADリクエストはボディを含まないため、通信量を削減
レスポンスヘッダーから X-File-Metadata を取得して _cached_metadata に保存


処理フローの改善

 変更前: GETリクエスト → WaterButler APIでメタデータ取得
 変更後: HEADリクエスト → ヘッダーからメタデータ取得 → キャッシュ使用

## Side effects

連携する変更（RDM-osf.io #612）
このプルリクエストは、RDM-osf.io #612 で追加された X-File-Metadata ヘッダーを活用します：

osf.io側: HEADリクエストのレスポンスに X-File-Metadata ヘッダーを追加
file-renderer側: そのヘッダーからメタデータを取得してキャッシュ

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

RDM-osf.io #612 → S3リージョン情報の保存とヘッダー追加
RDM-waterbutler #79 → リージョン情報の活用
RDM-modular-file-renderer #6 → メタデータキャッシュの活用
